### PR TITLE
fix: correct BatchNorm parameter name for PyTorch compatibility

### DIFF
--- a/pytorchocr/modeling/backbones/rec_lcnetv3.py
+++ b/pytorchocr/modeling/backbones/rec_lcnetv3.py
@@ -226,11 +226,11 @@ class LearnableRepLayer(nn.Module):
             return 0, 0
         elif isinstance(branch, ConvBNLayer):
             kernel = branch.conv.weight
-            running_mean = branch.bn._mean
-            running_var = branch.bn._variance
+            running_mean = branch.bn.running_mean
+            running_var = branch.bn.running_var
             gamma = branch.bn.weight
             beta = branch.bn.bias
-            eps = branch.bn._epsilon
+            eps = branch.bn.eps
         else:
             assert isinstance(branch, nn.BatchNorm2d)
             if not hasattr(self, 'id_tensor'):
@@ -244,11 +244,11 @@ class LearnableRepLayer(nn.Module):
                                  self.kernel_size // 2] = 1
                 self.id_tensor = kernel_value
             kernel = self.id_tensor
-            running_mean = branch._mean
-            running_var = branch._variance
+            running_mean = branch.running_mean
+            running_var = branch.running_var
             gamma = branch.weight
             beta = branch.bias
-            eps = branch._epsilon
+            eps = branch.eps
         std = (running_var + eps).sqrt()
         t = (gamma / std).reshape((-1, 1, 1, 1))
         return kernel * t, beta - running_mean * gamma / std


### PR DESCRIPTION
PaddleOCR v4 和 v5 的 mobile 识别模型使用的 backbone PPLCNetV3 在重参数化过程中存在参数转换错误。具体表现为在 LearnableRepLayer._get_kernel_bias() 方法中，代码尝试访问 _epsilon, _mean, _variance 等参数

The backbone PPLCNetV3 used in PaddleOCR v4 and v5 mobile recognition models has parameter conversion errors during reparameterization. Specifically, the LearnableRepLayer._get_kernel_bias() method attempts to access branch.bn._epsilon, _mean, _variance, etc